### PR TITLE
bug fix

### DIFF
--- a/hotstarlivestreamer.php
+++ b/hotstarlivestreamer.php
@@ -114,11 +114,9 @@ else{
 
 	$folder = ""; 
 
-	$ppid= strrpos($argv[1], '/');
+	preg_match_all('/\d+/', $argv[1], $matches);
 
-	$id = substr($argv[1], $ppid);
-
-	$pid=str_replace("/","",$id);
+	$pid = max($matches[0]);
 	
 	$title="http://account.hotstar.com/AVS/besc?action=GetAggregatedContentDetails&channel=PCTV&contentId=$pid";
 


### PR DESCRIPTION
Extracts content id from url, instead of assuming it to be at the end of url.  '/watch' bug should be fixed, This fix assumes the longest number in url would be content Id.