### PR TITLE
Update in sh files to prevent errors in other shells

### DIFF
--- a/hotstarlivestreamer.sh
+++ b/hotstarlivestreamer.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 echo "paste the link"
 read link
 last=${link: -1}

--- a/starsportslivestreamer.sh
+++ b/starsportslivestreamer.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 echo "paste the link"
 read link
 folder=$PWD/videos/

--- a/vootffmpeg.sh
+++ b/vootffmpeg.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 echo "paste the link"
 read link
 

--- a/vootlivestreamer.sh
+++ b/vootlivestreamer.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 echo "paste the link"
 read link
 


### PR DESCRIPTION
Without this patch, the sh files give error in linux, stating a bad substitution error, when used with a different shell like zsh